### PR TITLE
Add bike speed & turning delay

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -17,7 +17,8 @@ interface Player {
 const GRID_SIZE = 4;
 const GAME_WIDTH = 800;
 const GAME_HEIGHT = 600;
-const MOVE_SPEED = 120; // milliseconds between moves
+const MOVE_SPEED = 150; // milliseconds between moves (slower)
+const TURN_DELAY = 200; // milliseconds delay between consecutive turns
 
 const Game: React.FC = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -25,6 +26,7 @@ const Game: React.FC = () => {
   const [winner, setWinner] = useState<number | null>(null);
   const gameLoopRef = useRef<number>();
   const lastMoveTimeRef = useRef<number>(0);
+  const lastTurnTimeRef = useRef<Record<number, number>>({ 1: 0, 2: 0 });
   
   const [players, setPlayers] = useState<Player[]>([
     {
@@ -173,29 +175,41 @@ const Game: React.FC = () => {
   const handleKeyPress = useCallback((event: KeyboardEvent) => {
     if (gameState !== 'playing') return;
 
+    const now = performance.now();
+
     setPlayers(prevPlayers => prevPlayers.map(player => {
       if (player.id === 1) {
+        if (now - lastTurnTimeRef.current[1] < TURN_DELAY) return player;
         switch (event.key.toLowerCase()) {
           case 'w':
-            return player.direction !== 'down' ? { ...player, direction: 'up' } : player;
+            if (player.direction !== 'down') { lastTurnTimeRef.current[1] = now; return { ...player, direction: 'up' }; }
+            break;
           case 's':
-            return player.direction !== 'up' ? { ...player, direction: 'down' } : player;
+            if (player.direction !== 'up') { lastTurnTimeRef.current[1] = now; return { ...player, direction: 'down' }; }
+            break;
           case 'a':
-            return player.direction !== 'right' ? { ...player, direction: 'left' } : player;
+            if (player.direction !== 'right') { lastTurnTimeRef.current[1] = now; return { ...player, direction: 'left' }; }
+            break;
           case 'd':
-            return player.direction !== 'left' ? { ...player, direction: 'right' } : player;
+            if (player.direction !== 'left') { lastTurnTimeRef.current[1] = now; return { ...player, direction: 'right' }; }
+            break;
         }
       }
       if (player.id === 2) {
+        if (now - lastTurnTimeRef.current[2] < TURN_DELAY) return player;
         switch (event.key) {
           case 'ArrowUp':
-            return player.direction !== 'down' ? { ...player, direction: 'up' } : player;
+            if (player.direction !== 'down') { lastTurnTimeRef.current[2] = now; return { ...player, direction: 'up' }; }
+            break;
           case 'ArrowDown':
-            return player.direction !== 'up' ? { ...player, direction: 'down' } : player;
+            if (player.direction !== 'up') { lastTurnTimeRef.current[2] = now; return { ...player, direction: 'down' }; }
+            break;
           case 'ArrowLeft':
-            return player.direction !== 'right' ? { ...player, direction: 'left' } : player;
+            if (player.direction !== 'right') { lastTurnTimeRef.current[2] = now; return { ...player, direction: 'left' }; }
+            break;
           case 'ArrowRight':
-            return player.direction !== 'left' ? { ...player, direction: 'right' } : player;
+            if (player.direction !== 'left') { lastTurnTimeRef.current[2] = now; return { ...player, direction: 'right' }; }
+            break;
         }
       }
       return player;
@@ -224,6 +238,7 @@ const Game: React.FC = () => {
       }
     ]);
     lastMoveTimeRef.current = 0;
+    lastTurnTimeRef.current = { 1: 0, 2: 0 };
   };
 
   useEffect(() => {

--- a/src/components/Game3D.tsx
+++ b/src/components/Game3D.tsx
@@ -12,6 +12,10 @@ interface BikeState {
   maxHealth: number;
 }
 
+// Tunable gameplay constants
+const BIKE_SPEED = 0.12; // slightly slower default speed
+const TURN_DELAY_FRAMES = 20; // minimum frames between consecutive turns
+
 const Game3D: React.FC = () => {
   const mountRef = useRef<HTMLDivElement>(null);
   const sceneRef = useRef<THREE.Scene>();
@@ -32,7 +36,7 @@ const Game3D: React.FC = () => {
     rotation: 0,
     trail: [],
     alive: true,
-    speed: 0.15,
+    speed: BIKE_SPEED,
     lastTurnFrame: 0,
     health: 100,
     maxHealth: 100
@@ -180,9 +184,9 @@ const Game3D: React.FC = () => {
     let newRotation = bike.rotation;
     let newLastTurnFrame = bike.lastTurnFrame;
     
-    // Fixed turn delay - 15 frames between ANY turns for consistency
+    // Simple delay to keep consecutive turns slightly apart
     const framesSinceLastTurn = frameCountRef.current - bike.lastTurnFrame;
-    const canTurn = framesSinceLastTurn >= 15;
+    const canTurn = framesSinceLastTurn >= TURN_DELAY_FRAMES;
     
     if (canTurn) {
       // Check for left turn
@@ -351,7 +355,7 @@ const Game3D: React.FC = () => {
       rotation: 0,
       trail: [initialPosition.clone()],
       alive: true,
-      speed: 0.15,
+      speed: BIKE_SPEED,
       lastTurnFrame: 0,
       health: 100,
       maxHealth: 100


### PR DESCRIPTION
## Summary
- slow down the bike in both 2D and 3D modes
- restrict turning so consecutive turns require a short delay

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e6e961b788327ae0a8e915e5ec99f